### PR TITLE
Patch to update sequelize because of discovered vulnerability

### DIFF
--- a/ideas-conference-planner/package.json
+++ b/ideas-conference-planner/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "electron": "^4.0.1",
-    "sequelize": "^4.42",
+    "sequelize": "^5.3.0",
     "pg": "^7.8.0",
     "pg-hstore": "^2.3.2",
     "csv": "^5.1.1",


### PR DESCRIPTION
Security risk discovered in Sequelize <5.3.0, update to combat this issues.